### PR TITLE
Use nanopubs for displaying news on the main page (latest news) and on the news page

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,25 +84,11 @@ They all connect to an ecosystem that is fully open, semantic, decentralized, an
 
 <column>
 <h2>Our News</h2>
-<ul>
-
-<li>
-<span><span>We are happy to announce that we are part of three papers that have been accepted for presentation at the <a href="https://fairdo.org/fdo-conference-2026/" rel="nofollow">3rd FAIR Digital Objects Conference</a>. So we are looking forward to presenting our work in Vienna in March!</span></span>
-</li>
-
-<li>
-<span><span>Interested in nanopublications and how they could be useful to you? If so, come join the 
-<a href="https://w3id.org/spaces/fenac" rel="nofollow">Fearless Early Nanopub Adopter Club</a>!</span></span>
-</li>
-
-<li>
-<span><span>We are happy to announce that the final report for the FDO Connect project (a.k.a. FAIR Data Publisher) is now <a href="https://mission-ki.de/en/final-report-on-the-fair-data-publisher-a-foundation-for-interoperable-data-spaces-in-europe" rel="nofollow">available</a>.</span></span>
-</li>
+<ul id="latest-news"></ul>
 
 <buttons>
-<a href="news.html" class="button">See all</a>
+  <a href="news.html" class="button">See all</a>
 </buttons>
-</ul>
 
 </column>
 
@@ -246,6 +232,10 @@ Switzerland</p>
 
 </container>
 </section>
+<script type="module">
+  import { showLatestNews } from "./scripts/news.js";
+  showLatestNews();
+</script>
 
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -32,11 +32,10 @@
 
 </section>
 
-<section>
+<section data-year="2025">
 <h3>2025</h3>
 
-<ul>
-
+<ul id="news-items">
 <li>
 <span><span>We are happy to announce that we are part of three papers that have been accepted for presentation at the <a href="https://fairdo.org/fdo-conference-2026/" rel="nofollow">3rd FAIR Digital Objects Conference</a>. So we are looking forward to presenting our work in Vienna in March!</span></span>
 </li>
@@ -88,7 +87,7 @@
 </ul>
 </section>
 
-<section>
+<section data-year="2024">
 <h3>2024</h3>
 
 <ul>
@@ -100,7 +99,7 @@
 </ul>
 </section>
 
-<section>
+<section data-year="2023">
 <h3>2023</h3>
 
 <ul>
@@ -111,7 +110,7 @@
 </ul>
 </section>
 
-<section>
+<section data-year="2022">
 <h3>2022</h3>
 
 <ul>
@@ -119,6 +118,9 @@
 </ul>
 </section>
 
-
+  <script type="module">
+    import { showNewsItems } from "./scripts/news.js";
+    showNewsItems();
+  </script>
 </body>
 </html>

--- a/scripts/news.js
+++ b/scripts/news.js
@@ -36,27 +36,28 @@ export async function showNewsItems() {
 
 export function buildNewsItem({ text, link, np, datePublished }) {
   const li = document.createElement("li");
-  const outer = document.createElement("span");
-  const inner = document.createElement("span");
+  const span = document.createElement("span");
 
   if (text) {
     const clean = DOMPurify.sanitize(text);
-
     const doc = new DOMParser().parseFromString(clean, "text/html");
-    inner.append(...doc.body.childNodes);
+    span.append(...doc.body.childNodes);
   }
 
   if (link) {
     const a = document.createElement("a");
     a.href = link;
     a.rel = "nofollow";
-    a.appendChild(inner);
-    outer.appendChild(a);
-  } else {
-    outer.appendChild(inner);
+    a.textContent = link;
+    const inner = span.querySelector("span");
+    if (inner) {
+      inner.appendChild(a);
+    } else {
+      span.appendChild(a);
+    }
   }
 
-  li.appendChild(outer);
+  li.appendChild(span);
 
   if (datePublished) li.dataset.date = datePublished;
   if (np) li.dataset.nanopub = np;
@@ -134,10 +135,9 @@ export async function showLatestNews(limit = 3) {
         return new Date(b.datePublished) - new Date(a.datePublished);
       })
       .slice(0, limit)
-      .forEach(row => {
+      .forEach((row) => {
         ul.appendChild(buildNewsItem(row));
       });
-
   } catch (err) {
     stopLoading();
     console.error(err);

--- a/scripts/news.js
+++ b/scripts/news.js
@@ -1,0 +1,164 @@
+import { NanopubClient } from "https://esm.sh/@nanopub/nanopub-js@0.1.0";
+import DOMPurify from "https://esm.sh/dompurify@3.0.6";
+
+export async function showNewsItems() {
+  const client = new NanopubClient({
+    endpoints: ["https://query.knowledgepixels.com/"],
+  });
+
+  const container =
+    document.querySelector("section[data-year] ul") ||
+    document.getElementById("news-container");
+
+  const stopLoading = showLoadingMessage(container);
+
+  try {
+    for await (const row of client.runQueryTemplate(
+      "RAOGCU2nQzZ0aE2iXwJ20jJtnZsjVR0pfFg0qlSxYtBIA/get-news-content",
+      { resource: "https://w3id.org/spaces/knowledgepixels" }
+    )) {
+      stopLoading();
+
+      const year = row.datePublished
+        ? new Date(row.datePublished).getFullYear()
+        : new Date().getFullYear();
+
+      const ul = getYearList(year);
+      const li = buildNewsItem(row);
+
+      insertChronologically(ul, li);
+    }
+  } catch (err) {
+    stopLoading();
+    console.error(err);
+  }
+}
+
+export function buildNewsItem({ text, link, np, datePublished }) {
+  const li = document.createElement("li");
+  const outer = document.createElement("span");
+  const inner = document.createElement("span");
+
+  if (text) {
+    const clean = DOMPurify.sanitize(text);
+
+    const doc = new DOMParser().parseFromString(clean, "text/html");
+    inner.append(...doc.body.childNodes);
+  }
+
+  if (link) {
+    const a = document.createElement("a");
+    a.href = link;
+    a.rel = "nofollow";
+    a.appendChild(inner);
+    outer.appendChild(a);
+  } else {
+    outer.appendChild(inner);
+  }
+
+  li.appendChild(outer);
+
+  if (datePublished) li.dataset.date = datePublished;
+  if (np) li.dataset.nanopub = np;
+
+  return li;
+}
+
+function getYearList(year) {
+  let section = document.querySelector(`section[data-year="${year}"]`);
+
+  if (!section) {
+    section = document.createElement("section");
+    section.dataset.year = year;
+
+    const h3 = document.createElement("h3");
+    h3.textContent = year;
+
+    const ul = document.createElement("ul");
+
+    section.appendChild(h3);
+    section.appendChild(ul);
+
+    const all = [...document.querySelectorAll("section[data-year]")];
+    const before = all.find((s) => Number(s.dataset.year) < year);
+
+    document.body.insertBefore(section, before || null);
+  }
+
+  return section.querySelector("ul");
+}
+
+function insertChronologically(ul, li) {
+  const date = li.dataset.date;
+
+  if (!date) {
+    ul.prepend(li);
+    return;
+  }
+
+  const time = new Date(date).getTime();
+
+  const existing = [...ul.children];
+  const before = existing.find((el) => {
+    const d = el.dataset.date;
+    return d && new Date(d).getTime() < time;
+  });
+
+  ul.insertBefore(li, before || null);
+}
+
+export async function showLatestNews(limit = 3) {
+  const ul = document.getElementById("latest-news");
+  const stopLoading = showLoadingMessage(ul);
+
+  const client = new NanopubClient({
+    endpoints: ["https://query.knowledgepixels.com/"],
+  });
+
+  const rows = [];
+
+  try {
+    for await (const row of client.runQueryTemplate(
+      "RAOGCU2nQzZ0aE2iXwJ20jJtnZsjVR0pfFg0qlSxYtBIA/get-news-content",
+      { resource: "https://w3id.org/spaces/knowledgepixels" }
+    )) {
+      rows.push(row);
+    }
+
+    stopLoading();
+
+    rows
+      .sort((a, b) => {
+        if (!a.datePublished) return 1;
+        if (!b.datePublished) return -1;
+        return new Date(b.datePublished) - new Date(a.datePublished);
+      })
+      .slice(0, limit)
+      .forEach(row => {
+        ul.appendChild(buildNewsItem(row));
+      });
+
+  } catch (err) {
+    stopLoading();
+    console.error(err);
+  }
+}
+
+function showLoadingMessage(container, text = "Fetching news") {
+  const li = document.createElement("li");
+  li.className = "news-loading";
+  li.textContent = text;
+
+  let dots = 0;
+  const interval = setInterval(() => {
+    dots = (dots + 1) % 4;
+    li.textContent = text + ".".repeat(dots);
+  }, 400);
+
+  container.appendChild(li);
+
+  return () => {
+    clearInterval(interval);
+    li.remove();
+  };
+}

--- a/scripts/news.js
+++ b/scripts/news.js
@@ -1,5 +1,5 @@
 import { NanopubClient } from "https://esm.sh/@nanopub/nanopub-js@0.1.0";
-import DOMPurify from "https://esm.sh/dompurify@3.0.6";
+import DOMPurify from "https://esm.sh/dompurify@3.3.1";
 
 export async function showNewsItems() {
   const client = new NanopubClient({


### PR DESCRIPTION
This PR uses `nanopub-js` to fetch the news items and display them on the homepage (Our News section) and the News page. 

I used [esm.sh](https://esm.sh/) to import the dependencies so that we don't need the setup to build and deploy the project for use with GitHub Pages, but we can cross that bridge in the future. 